### PR TITLE
fix for error in task 'apt_key'

### DIFF
--- a/molecule/ubuntu/prepare.yml
+++ b/molecule/ubuntu/prepare.yml
@@ -13,10 +13,9 @@
       apt:
         update_cache: True
 
-    - name: dependency for apt_key
+    - name: Install gpg dependency
       apt:
         name: python3-gpg
         state: present
-        update_cache: true
 
 ...


### PR DESCRIPTION
I noticed that you have an error in your molecule action run
```
{"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"}
```
https://github.com/rolehippie/mariadb/runs/3712867920?check_suite_focus=true#step:4:117

but there will be another error after that
```
{"changed": false, "msg": "Failed to update apt cache: E:The repository 'https://mirror.netcologne.de/mariadb/repo/10.6/ubuntu bionic Release' does not have a Release file."}
```
https://github.com/gofrolist/mariadb/runs/3812973099?check_suite_focus=true#step:4:143